### PR TITLE
Assert that Task to be added is not null

### DIFF
--- a/src/main/java/duke/task/TaskManager.java
+++ b/src/main/java/duke/task/TaskManager.java
@@ -59,6 +59,7 @@ public class TaskManager {
      * @return Message containing the task just added and the updated number of tasks.
      */
     public String addTask(Task task) {
+        assert task != null : "Task should be initialised within xCommand::execute";
         taskList.add(task);
         int taskCount = getTaskCount();
         String pluralised = taskCount > 1 ? "tasks" : "task";


### PR DESCRIPTION
TaskManager::addTask assumes that the Task argument is a
valid Task and adds it directly to the taskList.

This makes null a valid argument and may cause unexpected exceptions
when we operate on it.

Let's add an assertion at the start of TaskManager::addTask that the
Task to be added cannot be null.